### PR TITLE
allow BHT’s Host Controller to be supported

### DIFF
--- a/SdDevice.c
+++ b/SdDevice.c
@@ -1085,7 +1085,7 @@ SdCardIdentification (
     return Status;
   }
 
-  if ((ControllerVer & 0xFF) == 2) {
+  if (((ControllerVer & 0xFF) == 2) || ((ControllerVer & 0xFF) == 3)) {
     S18r = TRUE;
   } else if (((ControllerVer & 0xFF) == 0) || ((ControllerVer & 0xFF) == 1)) {
     S18r = FALSE;

--- a/SdMmcPciHcDxe.c
+++ b/SdMmcPciHcDxe.c
@@ -528,6 +528,8 @@ SdMmcPciHcDriverBindingStart (
   UINT32                          RoutineNum;
   BOOLEAN                         MediaPresent;
   BOOLEAN                         Support64BitDma;
+  UINT16                          IntStatus;
+  UINT32                          value;
 
   DEBUG ((DEBUG_INFO, "SdMmcPciHcDriverBindingStart: Start\n"));
 
@@ -666,6 +668,41 @@ SdMmcPciHcDriverBindingStart (
       Private->Slot[Slot].Initialized = FALSE;
     }
   }
+  extern BOOLEAN BHT_Debug;
+  if(BhtHostPciSupport(Private->PciIo)&&BHT_Debug){
+		SdMmcHcRwMmio (Private->PciIo,0,0x110,TRUE,sizeof (value),&value);
+		Print(L"0x110: 0x%x\n",value);
+
+		SdMmcHcRwMmio (Private->PciIo,0,0x114,TRUE,sizeof (value),&value);
+		Print(L"0x114: 0x%x\n",value);
+		
+		SdMmcHcRwMmio (Private->PciIo,0,0x1a8,TRUE,sizeof (value),&value);
+		Print(L"MEM 1A8:: 0x%x\n",value);
+		SdMmcHcRwMmio (Private->PciIo,0,0x1ac,TRUE,sizeof (value),&value);
+		Print(L"MEM 1AC:: 0x%x\n",value);
+		SdMmcHcRwMmio (Private->PciIo,0,0x1B0,TRUE,sizeof (value),&value);
+		Print(L"MEM 1B0:: 0x%x\n",value);
+
+		Print(L" - pcr 0x304 = 0x%08x\n", PciBhtRead32(Private->PciIo, 0x304));
+		Print(L" - pcr 0x328 = 0x%08x\n", PciBhtRead32(Private->PciIo, 0x328));
+		Print(L" - pcr 0x3e4 = 0x%08x\n", PciBhtRead32(Private->PciIo, 0x3e4));
+
+		SdMmcHcRwMmio (Private->PciIo,0,0x040,TRUE,sizeof (value),&value);
+		Print(L"0x40: 0x%x\n",value);
+		
+		SdMmcHcRwMmio (Private->PciIo,0,SD_MMC_HC_PRESENT_STATE,TRUE,sizeof (value),&value);
+		Print(L"Present State: 0x%x\n",value);
+		SdMmcHcRwMmio (Private->PciIo,0,SD_MMC_HC_HOST_CTRL1,TRUE,sizeof (IntStatus),&IntStatus);
+		Print(L"Power&Host1: 0x%x\n",IntStatus);
+		SdMmcHcRwMmio (Private->PciIo,0,SD_MMC_HC_CLOCK_CTRL,TRUE,sizeof (IntStatus),&IntStatus);
+		Print(L"CLK: 0x%x\n",IntStatus);
+		SdMmcHcRwMmio (Private->PciIo,0,SD_MMC_HC_TIMEOUT_CTRL,TRUE,sizeof (IntStatus),&IntStatus);
+		Print(L"SWR&Timeout: 0x%x\n",IntStatus);
+		SdMmcHcRwMmio (Private->PciIo,0,SD_MMC_HC_NOR_INT_STS,TRUE,sizeof (value),&value);
+		Print(L"INR&IER: 0x%x\n",value);
+		SdMmcHcRwMmio (Private->PciIo,0,SD_MMC_HC_HOST_CTRL2,TRUE,sizeof (IntStatus),&IntStatus);
+		Print(L"Host2: 0x%x\n",IntStatus);
+  	}
 
   //
   // Enable 64-bit DMA support in the PCI layer if this controller

--- a/SdMmcPciHci.h
+++ b/SdMmcPciHci.h
@@ -543,4 +543,35 @@ SdMmcHcInitHost (
   IN SD_MMC_HC_SLOT_CAP     Capability
   );
 
+
+
+BOOLEAN 
+BhtHostPciSupport(EFI_PCI_IO_PROTOCOL *PciIo);
+UINT32 
+PciBhtRead32(EFI_PCI_IO_PROTOCOL *PciIo, UINT32 offset);
+void 
+PciBhtWrite32(EFI_PCI_IO_PROTOCOL *PciIo, UINT32 offset, UINT32 value);
+void 
+PciBhtOr32(EFI_PCI_IO_PROTOCOL *PciIo, UINT32 offset, UINT32 value);
+void 
+PciBhtAnd32(EFI_PCI_IO_PROTOCOL *PciIo, UINT32 offset, UINT32 value);
+
+
+
+
+#define PCI_DEV_ID_RJ		0x8320
+#define PCI_DEV_ID_SDS0		0x8420
+#define PCI_DEV_ID_SDS1		0x8421
+#define PCI_DEV_ID_FJ2		0x8520
+#define PCI_DEV_ID_SB0		0x8620
+#define PCI_DEV_ID_SB1		0x8621
+
+
+// O2/BHT add BAR1 for PCIR mapping registers
+// These registers is defined by O2/BHT, but we may follow name definition rule.
+#define	BHT_PCIRMappingVal	        (0x200)		/* PCI CFG Space Register Mapping Value Register */
+#define	BHT_PCIRMappingCtl	        (0x204)		/* PCI CFG Space Register Mapping Control Register */
+#define	BHT_PCIRMappingEn		  	(0x208)		/* PCI CFG Space Register Mapping Enable Register */
+#define	BHT_GPIOCTL			  		(0x210)		/* GPIO control register*/
+
 #endif


### PR DESCRIPTION
Extend Host Controller version to 4.0 and add some functions to judge
if host controller is BHT. If it is, switch the process to BHT’s process else 
use default process.